### PR TITLE
Thread Editor tooltip support: allow animations setting to be specified through config

### DIFF
--- a/draft-js-toolbar-plugin/package.json
+++ b/draft-js-toolbar-plugin/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "draft-js-toolbar-plugin",
-  "version": "2.0.0-beta.2",
+  "name": "@massdrop/draft-js-toolbar-plugin",
+  "version": "2.0.0",
   "description": "Toolbar Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/draft-js-toolbar-plugin/publish.sh
+++ b/draft-js-toolbar-plugin/publish.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+git pull
+
+# updates the package.json to have a new version, uses version in commit msg
+VERSION=$(npm version patch)
+VERSION=$(echo $VERSION | cut -c 2-)
+
+# In a monorepo setup, `npm version patch` will not automatically create a verion
+# commit because the package.json is not in the same directory as the monorepo's
+# .git directory. As a result, we need to create the version commit.
+git add package.json
+git commit -m $VERSION
+
+PACKAGE=$(npm pack)
+echo PACKAGE: $PACKAGE
+curl -F package=@$PACKAGE https://C__hqNZ_HngaWmEnB-ps@push.fury.io/massdrop/
+rm $PACKAGE
+git push

--- a/draft-js-toolbar-plugin/src/index.js
+++ b/draft-js-toolbar-plugin/src/index.js
@@ -7,7 +7,8 @@ import airToolbarHandler from './air-toolbar';
 
 const toolbarPlugin = (config = {}) => {
   const theme = config.theme || styles;
-  const toolbarHandler = config.toolbarHandler || { ...airToolbarHandler, ...config };
+  const defaultToolbarHandler = Object.assign(airToolbarHandler, config);
+  const toolbarHandler = config.toolbarHandler || defaultToolbarHandler;
   return {
     // Re-Render the text-toolbar onChange (on selection change)
     onChange: (editorState, { setEditorState }) => {


### PR DESCRIPTION
Changes for `draft-js-toolbar-plugin` only.

Unfortunately, the way the upstream repo sets up the default toolbar handler doesn't allow the `animations` setting to be changed via the `config` parameter; it's always set to `true`. This PR changes the setup of the default toolbar handler to actually utilize any `config` settings provided.

In addition, the package has been renamed to `@massdrop/draft-js-toolbar-plugin`. It will require publishing.
