### PR TITLE
Configurable link component for Draft JS Linkify plugin

### DIFF
--- a/draft-js-linkify-plugin/package.json
+++ b/draft-js-linkify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@massdrop/draft-js-linkify-plugin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Linkify Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "clean": "../node_modules/.bin/rimraf lib",
-    "build": "npm run clean && npm run build:js && npm run build:css",
+    "build": "npm run clean && npm run build:js",
     "build:js": "WEBPACK_CONFIG=$(pwd)/webpack.config.js BABEL_DISABLE_CACHE=1 BABEL_ENV=production NODE_ENV=production ../node_modules/.bin/babel --out-dir='lib' --ignore='__test__/*' src",
     "build:css": "node ../scripts/concatCssFiles $(pwd) && ../node_modules/.bin/rimraf lib-css",
     "prepublish": "npm run build"

--- a/draft-js-linkify-plugin/package.json
+++ b/draft-js-linkify-plugin/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "draft-js-linkify-plugin",
-  "version": "2.0.0-beta.2",
+  "name": "@massdrop/draft-js-linkify-plugin",
+  "version": "2.0.1",
   "description": "Linkify Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/draft-js-linkify-plugin/src/Link/index.js
+++ b/draft-js-linkify-plugin/src/Link/index.js
@@ -11,7 +11,6 @@ export default class Link extends Component {
     /* eslint-disable no-use-before-define */
     const {
       decoratedText = '',
-      component,
       target = '_self',
       className,
       ...props,
@@ -20,7 +19,7 @@ export default class Link extends Component {
     const links = linkify.match(decoratedText);
     const href = links && links[0] ? links[0].url : '';
     return (
-      <component
+      <this.props.component
         {...props}
         href={href}
         className={className}

--- a/draft-js-linkify-plugin/src/Link/index.js
+++ b/draft-js-linkify-plugin/src/Link/index.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import unionClassNames from 'union-class-names';
 import linkifyIt from 'linkify-it';
 import tlds from 'tlds';
 
@@ -12,20 +11,19 @@ export default class Link extends Component {
     /* eslint-disable no-use-before-define */
     const {
       decoratedText = '',
-      theme = {},
+      component,
       target = '_self',
       className,
       ...props,
       } = this.props;
     /* eslint-enable */
-    const combinedClassName = unionClassNames(theme.link, className);
     const links = linkify.match(decoratedText);
     const href = links && links[0] ? links[0].url : '';
     return (
-      <a
+      <component
         {...props}
         href={href}
-        className={combinedClassName}
+        className={className}
         target={target}
       />
     );

--- a/draft-js-linkify-plugin/src/index.js
+++ b/draft-js-linkify-plugin/src/index.js
@@ -1,26 +1,20 @@
 import Link from './Link';
 import linkStrategy from './linkStrategy';
-import styles from './styles.css';
 import decorateComponentWithProps from 'decorate-component-with-props';
 
-const defaultTheme = {
-  link: styles.link,
-};
-
 const linkPlugin = (config = {}) => {
-  // Styles are overwritten instead of merged as merging causes a lot of confusion.
-  //
-  // Why? Because when merging a developer needs to know all of the underlying
-  // styles which needs a deep dive into the code. Merging also makes it prone to
-  // errors when upgrading as basically every styling change would become a major
-  // breaking change. 1px of an increased padding can break a whole layout.
-  const theme = config.theme ? config.theme : defaultTheme;
+  const component = config.component;
   const target = config.target ? config.target : '_self';
+
+  if (!component) {
+    throw new Error('draft-js-linkify-plugin: Component not specified in initialization.');
+  }
+
   return {
     decorators: [
       {
         strategy: linkStrategy,
-        component: decorateComponentWithProps(Link, { theme, target }),
+        component: decorateComponentWithProps(Link, { component, target }),
       },
     ],
   };


### PR DESCRIPTION
Change the Draft JS Linkify plugin to take a component. We use this to inject our SafeLink component so that we get window.opener protection.

I have already published this version of the code to Gemfury: @massdrop/draft-js-linkify-plugin@2.0.2 .
##### Related PRs

https://github.com/Massdrop/massdrop/pull/706

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/massdrop/draft-js-plugins/2)

<!-- Reviewable:end -->
