### PR TITLE
Updated Mentions, Editor, Toolbar plugins to reference new forked version of draft-js

### DIFF
--- a/draft-js-linkify-plugin/package.json
+++ b/draft-js-linkify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@massdrop/draft-js-linkify-plugin",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Linkify Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -35,7 +35,6 @@
     "union-class-names": "^1.0.0",
     "linkify-it": "2.0.0",
     "tlds": "1.132.0",
-    "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",
     "react": ">=15.1.0",
     "react-dom": ">=15.1.0"

--- a/draft-js-mention-plugin/package.json
+++ b/draft-js-mention-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@massdrop/draft-js-mention-plugin",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "description": "Mention Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -34,7 +34,7 @@
     "decorate-component-with-props": "^1.0.2",
     "find-with-regex": "^1.0.2",
     "union-class-names": "^1.0.0",
-    "draft-js": ">=0.7.0",
+    "@massdrop/draft-js": "0.7.1",
     "immutable": ">=3.8.1",
     "react": ">=15.1.0",
     "react-dom": ">=15.1.0"

--- a/draft-js-mention-plugin/src/Mention/index.js
+++ b/draft-js-mention-plugin/src/Mention/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Entity } from 'draft-js';
+import { Entity } from '@massdrop/draft-js';
 import { fromJS } from 'immutable';
 
 const Mention = (props) => {

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -3,7 +3,7 @@ import React, { Component, PropTypes } from 'react';
 import Entry from './Entry';
 import addMention from '../modifiers/addMention';
 import decodeOffsetKey from '../utils/decodeOffsetKey';
-import { genKey } from 'draft-js';
+import { genKey } from '@massdrop/draft-js';
 import getSearchText from '../utils/getSearchText';
 
 export default class MentionSuggestions extends Component {

--- a/draft-js-mention-plugin/src/mentionStrategy.js
+++ b/draft-js-mention-plugin/src/mentionStrategy.js
@@ -1,4 +1,4 @@
-import { Entity } from 'draft-js';
+import { Entity } from '@massdrop/draft-js';
 
 const findMention = (character) => {
   const entityKey = character.getEntity();

--- a/draft-js-mention-plugin/src/modifiers/addMention.js
+++ b/draft-js-mention-plugin/src/modifiers/addMention.js
@@ -1,4 +1,4 @@
-import { Modifier, EditorState, Entity } from 'draft-js';
+import { Modifier, EditorState, Entity } from '@massdrop/draft-js';
 import getSearchText from '../utils/getSearchText';
 
 const addMention = (editorState, mention, entityMutability) => {

--- a/draft-js-plugins-editor/package.json
+++ b/draft-js-plugins-editor/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "draft-js-plugins-editor",
-  "version": "2.0.0-beta.2",
+  "name": "@massdrop/draft-js-plugins-editor",
+  "version": "2.0.1",
   "description": "Editor for DraftJS Plugins",
   "author": {
     "name": "Nik Graf",
@@ -31,7 +31,7 @@
     "decorate-component-with-props": "^1.0.2",
     "find-with-regex": "^1.0.2",
     "union-class-names": "^1.0.0",
-    "draft-js": ">=0.7.0",
+    "@massdrop/draft-js": "0.7.1",
     "immutable": ">=3.8.1",
     "react": ">=15.1.0",
     "react-dom": ">=15.1.0"

--- a/draft-js-plugins-editor/src/Editor/createCompositeDecorator.js
+++ b/draft-js-plugins-editor/src/Editor/createCompositeDecorator.js
@@ -3,7 +3,7 @@
  */
 
 import { List } from 'immutable';
-import { CompositeDecorator } from 'draft-js';
+import { CompositeDecorator } from '@massdrop/draft-js';
 import decorateComponentWithProps from 'decorate-component-with-props';
 
 export default (decorators, getEditorState, setEditorState) => {

--- a/draft-js-plugins-editor/src/Editor/defaultKeyBindingPlugin.js
+++ b/draft-js-plugins-editor/src/Editor/defaultKeyBindingPlugin.js
@@ -1,4 +1,4 @@
-import { getDefaultKeyBinding } from 'draft-js';
+import { getDefaultKeyBinding } from '@massdrop/draft-js';
 
 /**
  * Handle default key bindings.

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   Editor,
   EditorState,
-} from 'draft-js';
+} from '@massdrop/draft-js';
 
 import createCompositeDecorator from './createCompositeDecorator';
 import moveSelectionToEnd from './moveSelectionToEnd';

--- a/draft-js-plugins-editor/src/Editor/moveSelectionToEnd.js
+++ b/draft-js-plugins-editor/src/Editor/moveSelectionToEnd.js
@@ -1,7 +1,7 @@
 import {
   EditorState,
   SelectionState,
-} from 'draft-js';
+} from '@massdrop/draft-js';
 
 /**
  * Returns a new EditorState where the Selection is at the end.

--- a/draft-js-plugins-editor/src/utils/createEditorStateWithText.js
+++ b/draft-js-plugins-editor/src/utils/createEditorStateWithText.js
@@ -5,6 +5,6 @@
 import {
   ContentState,
   EditorState,
-} from 'draft-js';
+} from '@massdrop/draft-js';
 
 export default (text) => EditorState.createWithContent(ContentState.createFromText(text));

--- a/draft-js-toolbar-plugin/package.json
+++ b/draft-js-toolbar-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@massdrop/draft-js-toolbar-plugin",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "description": "Toolbar Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",
@@ -33,7 +33,7 @@
     "decorate-component-with-props": "^1.0.2",
     "find-with-regex": "^1.0.2",
     "union-class-names": "^1.0.0",
-    "draft-js": ">=0.7.0",
+    "@massdrop/draft-js": "0.7.1",
     "immutable": ">=3.8.1",
     "react": ">=15.1.0",
     "react-dom": ">=15.1.0"

--- a/draft-js-toolbar-plugin/src/Link/index.js
+++ b/draft-js-toolbar-plugin/src/Link/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Entity } from 'draft-js';
+import { Entity } from '@massdrop/draft-js';
 
 const Link = (props) => {
   const { href } = Entity.get(props.entityKey).getData();

--- a/draft-js-toolbar-plugin/src/actions/custom.js
+++ b/draft-js-toolbar-plugin/src/actions/custom.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RichUtils, Entity } from 'draft-js';
+import { RichUtils, Entity } from '@massdrop/draft-js';
 
 export default [
   {

--- a/draft-js-toolbar-plugin/src/linkStrategy.js
+++ b/draft-js-toolbar-plugin/src/linkStrategy.js
@@ -1,4 +1,4 @@
-import { Entity } from 'draft-js';
+import { Entity } from '@massdrop/draft-js';
 
 function findLinkEntities(contentBlock, callback) {
   contentBlock.findEntityRanges(

--- a/draft-js-toolbar-plugin/src/utils/textToolbar.js
+++ b/draft-js-toolbar-plugin/src/utils/textToolbar.js
@@ -1,4 +1,4 @@
-import { RichUtils } from 'draft-js';
+import { RichUtils } from '@massdrop/draft-js';
 import defaultInlineStyles from '../actions/inlineStyles';
 import defaultActions from '../actions/custom';
 import getSelection from '../utils/getSelection';


### PR DESCRIPTION
- Updated Mentions, Editor, Toolbar plugins to reference new forked version `@massdrop/draft-js`
- Also updated plugin version number. Removed `draft-js` dependency in `package.json` from Linkify plugin as it was not referenced anywhere
- All plugins have been updated in Gemfury.

**New `draft-js` forked version**
https://github.com/Massdrop/draft-js/pull/1

**Associated React changes**
https://github.com/Massdrop/massdrop/pull/965

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/massdrop/draft-js-plugins/4)

<!-- Reviewable:end -->
