### PR TITLE
Jlai/static version find with regex dependency

### DIFF
--- a/draft-js-mention-plugin/package.json
+++ b/draft-js-mention-plugin/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "1.1.0",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-mention-plugin/package.json
+++ b/draft-js-mention-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@massdrop/draft-js-mention-plugin",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Mention Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.1.0",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",


### PR DESCRIPTION
temporary measure to workaround recent versions of `find-with-regex` breaking our dependency on draft-js-mention-plugin

https://github.com/draft-js-plugins/find-with-regex/commits/master
reverts to commit 1.0.2 before this commit 
https://github.com/draft-js-plugins/find-with-regex/commit/3589831dd414adac5e7627e68fad83c47e496abb
https://github.com/draft-js-plugins/find-with-regex/commit/23eb5de85b4f63dad2df3354db7c64d26caca514

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/massdrop/draft-js-plugins/5)
<!-- Reviewable:end -->
