### PR TITLE
Pin find-with-regex version because new version breaks build

### DIFF
--- a/draft-js-alignment-plugin/package.json
+++ b/draft-js-alignment-plugin/package.json
@@ -35,7 +35,7 @@
     "react": ">=15.1.0",
     "react-dom": ">=15.1.0",
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0"
   }
 }

--- a/draft-js-cleanup-empty-plugin/package.json
+++ b/draft-js-cleanup-empty-plugin/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-dnd-plugin/package.json
+++ b/draft-js-dnd-plugin/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-emoji-plugin/package.json
+++ b/draft-js-emoji-plugin/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-entity-props-plugin/package.json
+++ b/draft-js-entity-props-plugin/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-focus-plugin/package.json
+++ b/draft-js-focus-plugin/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-hashtag-plugin/package.json
+++ b/draft-js-hashtag-plugin/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-image-plugin/package.json
+++ b/draft-js-image-plugin/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-mention-plugin/package.json
+++ b/draft-js-mention-plugin/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-plugins-editor/package.json
+++ b/draft-js-plugins-editor/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-resizeable-plugin/package.json
+++ b/draft-js-resizeable-plugin/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-sticker-plugin/package.json
+++ b/draft-js-sticker-plugin/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-table-plugin/package.json
+++ b/draft-js-table-plugin/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/draft-js-toolbar-plugin/package.json
+++ b/draft-js-toolbar-plugin/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
     "immutable": ">=3.8.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "decorate-component-with-props": "^1.0.2",
     "draft-js": "^0.7.0",
     "eslint-plugin-import": "^1.9.2",
-    "find-with-regex": "^1.0.2",
+    "find-with-regex": "1.0.2",
     "immutable": "^3.8.1",
     "linkify-it": "2.0.0",
     "loader-utils": "^0.2.15",


### PR DESCRIPTION
The introduction of flow types in the find-with-regex package is breaking our builds. Pinning the version for now to fix master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/massdrop/draft-js-plugins/6)
<!-- Reviewable:end -->
